### PR TITLE
Enable copying path to input URL in project #1120

### DIFF
--- a/scanpipe/templates/scanpipe/panels/project_inputs.html
+++ b/scanpipe/templates/scanpipe/panels/project_inputs.html
@@ -29,7 +29,7 @@
         {% if input_source.filename %}
           {{ input_source.filename }}
         {% else %}
-          {{ input_source.download_url }}
+          <a href="{{ input_source.download_url }}" title="{{ input_source.download_url }}">{{ input_source.download_url }}</a>
         {% endif %}
       </div>
       <div class="is-flex is-size-7">


### PR DESCRIPTION
This PR fixes https://github.com/nexB/scancode.io/issues/1120

Intially the input URL was not clickable and easy to copy.
![image](https://github.com/nexB/scancode.io/assets/103296906/36a8ec1c-23f2-444f-92b3-a9c1b67a9895)


Now, I have changed the input URL to a hyperlink so when clicked it will open the URL and can be copied easily.
![image](https://github.com/nexB/scancode.io/assets/103296906/e3e4e389-c53b-4826-8c19-6a830484cd3e)



please let me know if this solution works fine or not. Thanks.