### PR TITLE
Add android_inspector in new extra_requires #1373

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+v34.8.2 (unreleased)
+--------------------
+
+- Add ``android_analysis`` to ``extra_requires``. This installs the package
+  ``android_inspector``, which provides a pipeline for Android APK
+  deploy-to-development analysis.
+
 v34.8.1 (2024-09-06)
 --------------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -121,6 +121,9 @@ dev =
     # Release
     bumpver==2023.1129
 
+android_analysis =
+    android_inspector==0.0.1
+
 [options.entry_points]
 console_scripts =
     scanpipe = scancodeio:command_line


### PR DESCRIPTION
This PR adds a new extra_requires for android d2d. The android_inspector package provides scancode.io pipes and pipelines to perform android apk d2d.

#1366 #1371 #1372 #1373