### PR TITLE
Bump go-inspector to v0.4.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -80,7 +80,7 @@ install_requires =
     fetchcode-container==1.2.3.210512; sys_platform == "linux"
     # Inspectors
     elf-inspector==0.0.1
-    go-inspector==0.3.1
+    go-inspector==0.4.0
     python-inspector==0.12.1
     source-inspector==0.5.1; sys_platform != "darwin" and platform_machine != "arm64"
     aboutcode-toolkit==11.0.0


### PR DESCRIPTION
Reference: https://github.com/aboutcode-org/go-inspector/pull/17
https://pypi.org/project/go-inspector/0.4.0/