### PR TITLE
Do not fail on invalid extracted requirements

### DIFF
--- a/scanpipe/pipes/purldb.py
+++ b/scanpipe/pipes/purldb.py
@@ -320,9 +320,9 @@ def get_unique_unresolved_purls(project):
                 vers = range_class.from_native(extracted_requirement)
             except (InvalidVersionRange, InvalidVersion) as exception:
                 if exception is InvalidVersionRange:
-                    description = "Invalid VersionRange"
+                    description = "Version range is invalid or unsupported"
                 else:
-                    description = "Invalid exctracted requirement"
+                    description = "Extracted requirement is not a valid version"
                 details = {
                     "purl": purl,
                     "extracted_requirement": extracted_requirement,

--- a/scanpipe/pipes/purldb.py
+++ b/scanpipe/pipes/purldb.py
@@ -31,6 +31,7 @@ import requests
 from packageurl import PackageURL
 from univers.version_range import RANGE_CLASS_BY_SCHEMES
 from univers.version_range import InvalidVersionRange
+from univers.versions import InvalidVersion
 
 from aboutcode.pipeline import LoopProgress
 from scanpipe.pipes import _clean_package_data
@@ -300,28 +301,43 @@ def get_unique_resolved_purls(project):
 def get_unique_unresolved_purls(project):
     """Return PURLs from project's unresolved DiscoveredDependencies."""
     packages_unresolved = project.discovereddependencies.filter(
-        is_pinned=False
+        is_pinned=False,
     ).exclude(extracted_requirement="*")
 
-    distinct_unresolved_results = packages_unresolved.values(
+    distinct_unpinned_results = packages_unresolved.values(
         "type", "namespace", "name", "extracted_requirement"
     )
 
-    distinct_unresolved = {tuple(item.values()) for item in distinct_unresolved_results}
+    distinct_unpinned = {tuple(item.values()) for item in distinct_unpinned_results}
 
     packages = set()
-    for item in distinct_unresolved:
+    for item in distinct_unpinned:
         pkg_type, namespace, name, extracted_requirement = item
         if range_class := RANGE_CLASS_BY_SCHEMES.get(pkg_type):
+            purl = PackageURL(type=pkg_type, namespace=namespace, name=name)
+
             try:
                 vers = range_class.from_native(extracted_requirement)
-            except InvalidVersionRange:
+            except (InvalidVersionRange, InvalidVersion) as exception:
+                if exception is InvalidVersionRange:
+                    description = "Invalid VersionRange"
+                else:
+                    description = "Invalid exctracted requirement"
+                details = {
+                    "purl": purl,
+                    "extracted_requirement": extracted_requirement,
+                }
+                project.add_error(
+                    description=description,
+                    model="get_unique_unresolved_purls",
+                    details=details,
+                    exception=exception,
+                )
                 continue
 
             if not vers.constraints:
                 continue
 
-            purl = PackageURL(type=pkg_type, namespace=namespace, name=name)
             packages.add((str(purl), str(vers)))
 
     return packages

--- a/scanpipe/tests/__init__.py
+++ b/scanpipe/tests/__init__.py
@@ -230,6 +230,21 @@ dependency_data3 = {
     "datasource_id": "pypi_sdist_pkginfo",
 }
 
+dependency_data4 = {
+    "purl": "pkg:npm/wrap-ansi-cjs",
+    "package_type": "npm",
+    "extracted_requirement": "npm:wrap-ansi@^7.0.0",
+    "scope": "devDependencies",
+    "is_runtime": False,
+    "is_optional": True,
+    "is_pinned": False,
+    "is_direct": True,
+    "dependency_uid": "pkg:npm/wrap-ansi-cjs?uuid=e656b571-7d3f-46d1-b95b-8f037aef9692",
+    "for_package_uid": "",
+    "datafile_path": "",
+    "datasource_id": "npm_package_lock_json",
+}
+
 license_policies = [
     {
         "license_key": "apache-2.0",

--- a/scanpipe/tests/pipes/test_purldb.py
+++ b/scanpipe/tests/pipes/test_purldb.py
@@ -87,7 +87,9 @@ class ScanPipePurlDBTest(TestCase):
 
         self.assertEqual(set(), result)
         error_message = self.project1.projectmessages.all()[0]
-        self.assertEqual("Invalid exctracted requirement", error_message.description)
+        self.assertEqual(
+            "Extracted requirement is not a valid version", error_message.description
+        )
 
     @mock.patch("scanpipe.pipes.purldb.request_post")
     @mock.patch("scanpipe.pipes.purldb.is_available")

--- a/scanpipe/tests/pipes/test_purldb.py
+++ b/scanpipe/tests/pipes/test_purldb.py
@@ -36,6 +36,7 @@ from scanpipe.models import Run
 from scanpipe.pipes import purldb
 from scanpipe.tests import dependency_data2
 from scanpipe.tests import dependency_data3
+from scanpipe.tests import dependency_data4
 from scanpipe.tests import make_package
 from scanpipe.tests import package_data1
 
@@ -79,6 +80,14 @@ class ScanPipePurlDBTest(TestCase):
         result = purldb.get_unique_unresolved_purls(self.project1)
 
         self.assertEqual(expected, result)
+
+    def test_scanpipe_pipes_purldb_get_unique_unresolved_purls_error(self):
+        DiscoveredDependency.create_from_data(self.project1, dependency_data4)
+        result = purldb.get_unique_unresolved_purls(self.project1)
+
+        self.assertEqual(set(), result)
+        error_message = self.project1.projectmessages.all()[0]
+        self.assertEqual("Invalid exctracted requirement", error_message.description)
 
     @mock.patch("scanpipe.pipes.purldb.request_post")
     @mock.patch("scanpipe.pipes.purldb.is_available")


### PR DESCRIPTION
We were getting pipeline failures on wrongly parsed extracted requirements in someplaces:

```
'npm:wrap-ansi@^7.0.0' is not a valid <class 'univers.versions.SemverVersion'>

Traceback:
  File "/opt/scancodeio/aboutcode/pipeline/__init__.py", line 199, in execute
    step(self)
  File "/opt/scancodeio/scanpipe/pipelines/populate_purldb.py", line 48, in populate_purldb_with_discovered_dependencies
    purldb.populate_purldb_with_discovered_dependencies(
  File "/opt/scancodeio/scanpipe/pipes/purldb.py", line 364, in populate_purldb_with_discovered_dependencies
    unresolved_packages = get_unique_unresolved_purls(project)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/scancodeio/scanpipe/pipes/purldb.py", line 317, in get_unique_unresolved_purls
    vers = range_class.from_native(extracted_requirement)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/scancodeio/.venv/lib/python3.12/site-packages/univers/version_range.py", line 428, in from_native
    comparator=comparator, version=vrc(version_constraint)
                                   ^^^^^^^^^^^^^^^^^^^^^^^
  File "<attrs generated init univers.versions.Version>", line 7, in __init__
    self.__attrs_post_init__()
  File "/opt/scancodeio/.venv/lib/python3.12/site-packages/univers/versions.py", line 87, in __attrs_post_init__
    raise InvalidVersion(f"{self.string!r} is not a valid {self.__class__!r}")
```

* We should not fail the entire pipeline here, we were already catching InvalidVersionRange exceptions, but we also need to catch InvalidVersion exceptions here
* Also adding project errors on invalid versions/version ranges as these can be package manifest parsing bugs.