### PR TITLE
Do not check docker image checksums

### DIFF
--- a/scanpipe/pipes/docker.py
+++ b/scanpipe/pipes/docker.py
@@ -69,7 +69,7 @@ def extract_images_from_inputs(project):
     return images, errors
 
 
-def extract_image_from_tarball(input_tarball, extract_target, verify=True):
+def extract_image_from_tarball(input_tarball, extract_target, verify=False):
     """
     Extract images from an ``input_tarball`` to an ``extract_target`` directory
     Path object and collects the extracted images.


### PR DESCRIPTION
It can be useful to skip checking docker image checksums. It may need to to be made a project setting.
For now, this is only removing the verification step