### PR TITLE
Bump commoncode to v32.2.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -75,6 +75,7 @@ install_requires =
     scancode-toolkit[packages]==32.3.2
     extractcode[full]==31.0.0
     commoncode==32.2.0
+    Beautifulsoup4[chardet]==4.13.3
     packageurl-python==0.16.0
     # FetchCode
     fetchcode-container==1.2.3.210512; sys_platform == "linux"

--- a/setup.cfg
+++ b/setup.cfg
@@ -74,7 +74,7 @@ install_requires =
     # ScanCode-toolkit
     scancode-toolkit[packages]==32.3.2
     extractcode[full]==31.0.0
-    commoncode==32.1.0
+    commoncode==32.2.0
     packageurl-python==0.16.0
     # FetchCode
     fetchcode-container==1.2.3.210512; sys_platform == "linux"


### PR DESCRIPTION
Bumps commoncode to [v32.2.0](https://github.com/aboutcode-org/commoncode/releases/tag/v32.2.0)
This fixes breaking change introduced in beautifulsoup, see issue: https://github.com/aboutcode-org/commoncode/issues/79 fixed at https://github.com/aboutcode-org/commoncode/pull/80 by @jloehel

References:
* https://github.com/aboutcode-org/scancode.io/issues/1577
* https://github.com/aboutcode-org/scancode.io/issues/1578
* https://github.com/aboutcode-org/scancode-toolkit/issues/4129