### PR TITLE
Add extracted_to and extracted_from methods

### DIFF
--- a/scanpipe/models.py
+++ b/scanpipe/models.py
@@ -2889,6 +2889,18 @@ class CodebaseResource(
             if not topdown:
                 yield child
 
+    def extracted_to(self, codebase=None):
+        """Return the path this Resource archive was extracted to or None."""
+        extract_path = f"{self.path}-extract"
+        return self.project.get_resource(extract_path)
+
+    def extracted_from(self, codebase=None):
+        """Return the path to an archive this Resource was extracted from or None."""
+        path = self.path
+        if "-extract" in path:
+            archive_path, _, _ = self.path.rpartition("-extract")
+            return self.project.get_resource(archive_path)
+
     def get_absolute_url(self):
         return reverse("resource_detail", args=[self.project.slug, self.path])
 

--- a/scanpipe/tests/test_models.py
+++ b/scanpipe/tests/test_models.py
@@ -1467,6 +1467,19 @@ class ScanPipeModelsTest(TestCase):
 
         self.assertEqual(expected, result)
 
+    def test_scanpipe_codebase_resource_model_commoncode_methods_extracted_to_from(
+        self,
+    ):
+        archive_resource = CodebaseResource.objects.create(
+            project=self.project1, path="sample-archive.jar"
+        )
+        extracted_dir_resource = CodebaseResource.objects.create(
+            project=self.project1, path="sample-archive.jar-extract"
+        )
+
+        self.assertEqual(extracted_dir_resource, archive_resource.extracted_to())
+        self.assertEqual(archive_resource, extracted_dir_resource.extracted_from())
+
     def test_scanpipe_codebase_resource_model_compliance_alert(self):
         scanpipe_app.license_policies_index = license_policies_index
         resource = CodebaseResource.objects.create(project=self.project1, path="file")


### PR DESCRIPTION
Adds methods in CodebaseResource objects to navigate from an archive to their corresponding extracted directory and vice versa. This is added to match the functions in commoncode.resource.Resource so these functions work in the scancode.io context similarly to how they work in the scancode-toolkit context.

Reference: https://github.com/aboutcode-org/scancode.io/issues/1585