### PR TITLE
#1581 Issue: Sorting the Compliance Alerts of each project based on thier Severity level 

### DIFF
--- a/scanpipe/pipes/compliance.py
+++ b/scanpipe/pipes/compliance.py
@@ -61,6 +61,7 @@ def analyze_compliance_licenses(project):
         scan_results, scan_errors = scancode.scan_file(codebase_resource.location)
         codebase_resource.set_scan_results(scan_results)
 
+SEVERITY_ORDER = ["error", "warning", "missing", ""]
 
 def group_compliance_alerts_by_severity(queryset):
     """
@@ -108,4 +109,13 @@ def get_project_compliance_alerts(project, fail_level="error"):
         if (compliance_alerts := group_compliance_alerts_by_severity(queryset))
     }
 
-    return project_compliance_alerts
+    sorted_alerts = {}
+    for model_name, alerts in project_compliance_alerts.items():
+        sorted_dict = {}
+        for severity in SEVERITY_ORDER:
+            if severity in alerts:
+                sorted_dict[severity] = alerts[severity]
+        sorted_alerts[model_name] = sorted_dict
+
+
+    return sorted_alerts


### PR DESCRIPTION
Hello @pombredanne 
Addressing Issue #1581 
We want the order of severity levels as: **error > warning > missing > '' (empty string)** on a high level priority policy.

Earlier the dictionary storing the Severity levels of each project was not sorted, made changes to enforce the priority level.

Now the Compliance Alerts Panel will show all projects in uniform order.