### PR TITLE
fix(docker): Update air gap installation configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,7 @@ docker-images:
 	@echo "-> Save the service images to a tar archive in the build/ directory"
 	@rm -rf build/
 	@mkdir -p build/
-	@docker save postgres redis scancodeio-worker scancodeio-web nginx | gzip > build/scancodeio-images.tar.gz
+	@docker save postgres redis scancodeio-worker scancodeio-web nginx clamav/clamav | gzip > build/scancodeio-images.tar.gz
 
 offline-package: docker-images
 	@echo "-> Build package for offline installation in dist/"

--- a/docker-compose-offline.yml
+++ b/docker-compose-offline.yml
@@ -15,7 +15,7 @@ services:
       - redis_data:/data
 
   web:
-    image: scancodeio_web
+    image: scancodeio-web
     command: sh -c "
         ./manage.py migrate &&
         ./manage.py collectstatic --no-input --verbosity 0 --clear &&
@@ -32,8 +32,12 @@ services:
       - db
 
   worker:
-    image: scancodeio_worker
-    command: wait-for-it web:8000 -- ./manage.py rqworker --worker-class scancodeio.worker.ScanCodeIOWorker --queue-class scancodeio.worker.ScanCodeIOQueue --verbosity 2
+    image: scancodeio-worker
+    # Ensure that potential db migrations run first by waiting until "web" is up
+    command: wait-for-it --strict --timeout=120 web:8000 -- sh -c "
+        ./manage.py rqworker --worker-class scancodeio.worker.ScanCodeIOWorker
+                             --queue-class scancodeio.worker.ScanCodeIOQueue
+                             --verbosity 1"
     env_file:
       - docker.env
     volumes:
@@ -42,7 +46,7 @@ services:
     depends_on:
       - redis
       - db
-      - web # Ensure that potential db migrations run first
+      - web
 
   nginx:
     image: nginx
@@ -55,8 +59,16 @@ services:
     depends_on:
       - web
 
+  clamav:
+    image: clamav/clamav
+    volumes:
+      - clamav_data:/var/lib/clamav
+      - workspace:/var/scancodeio/workspace/
+    restart: always
+
 volumes:
   db_data:
   redis_data:
+  clamav_data:
   static:
   workspace:

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -182,6 +182,10 @@ and scripts on your local machine::
 A tarball ``scancodeio-offline-package-VERSION.tar`` will be
 created in the :guilabel:`dist/` directory.
 
+.. note::
+    The offline package includes all necessary Docker images: postgres, redis, 
+    scancodeio-web, scancodeio-worker, nginx, and clamav/clamav.
+
 Install on an offline server
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -183,7 +183,7 @@ A tarball ``scancodeio-offline-package-VERSION.tar`` will be
 created in the :guilabel:`dist/` directory.
 
 .. note::
-    The offline package includes all necessary Docker images: postgres, redis, 
+    The offline package includes all necessary Docker images: postgres, redis,
     scancodeio-web, scancodeio-worker, nginx, and clamav/clamav.
 
 Install on an offline server


### PR DESCRIPTION
### **Closes #1579** 

This PR addresses issues with the air gap installation configuration, ensuring proper image names, unified command formats, and inclusion of the ClamAV service.

**Changes**
- Fixed image names in `docker-compose-offline.yml`:
  - Changed `scancodeio_web` to `scancodeio-web`
  - Changed `scancodeio_worker` to `scancodeio-worker`
```
image: scancodeio-web
    networks:
      default: null
    volumes:
      - type: bind
        source: /etc/scancodeio/
        target: /etc/scancodeio
        bind:
          create_host_path: true
      - type: volume
        source: workspace
        target: /var/scancodeio/workspace
        volume: {}
      - type: volume
        source: static
        target: /var/scancodeio/static
        volume: {}
```
```
image: scancodeio-worker
    networks:
      default: null
    volumes:
      - type: bind
        source: /etc/scancodeio/
        target: /etc/scancodeio
        bind:
          create_host_path: true
      - type: volume
        source: workspace
        target: /var/scancodeio/workspace
        volume: {}
```
 
- Unified worker command format:
  - Standardized command structure between `docker-compose.yml` and `docker-compose-offline.yml`
  - Updated verbosity level from 2 to 1
```
 command: wait-for-it --strict --timeout=120 web:8000 -- sh -c "
    ./manage.py rqworker --worker-class scancodeio.worker.ScanCodeIOWorker
                         --queue-class scancodeio.worker.ScanCodeIOQueue
                         --verbosity 1"
```
 
- Added ClamAV service and configuration:
  - Added ClamAV service to `docker-compose-offline.yml`
  - Added corresponding volume configuration
  - Updated Makefile to include ClamAV in docker-images target
```
clamav:
    image: clamav/clamav
    networks:
      default: null
    restart: always
    volumes:
      - type: volume
        source: clamav_data
        target: /var/lib/clamav
        volume: {}
      - type: volume
        source: workspace
        target: /var/scancodeio/workspace
        volume: {}
```
- Updated documentation:
  - Added note about ClamAV image in offline package
```
@docker save postgres redis scancodeio-worker scancodeio-web nginx clamav/clamav | gzip > build/scancodeio-images.tar.gz
```

**Validation**

- Confirmed configuration validity using docker compose config
- Verified that both configurations match except for expected differences (image vs. build)
- Compared configurations using `vimdiff` as suggested in the issue 

**Notes**

- Unable to fully test build process due to architecture compatibility issues on ARM-based Mac
- All configuration changes have been validated for syntax correctness

**Related Issues**

- Fixes #1579 - Air gap installation configuration issues