### PR TITLE
Only process match results for file matches

### DIFF
--- a/scanpipe/pipes/matchcode.py
+++ b/scanpipe/pipes/matchcode.py
@@ -408,6 +408,8 @@ def create_packages_from_match_results(project, match_results):
         )
     match_resources = match_results.get("files", [])
     for match_resource in match_resources:
+        if match_resource["type"] != "file":
+            continue
         match_resource_extra_data = match_resource["extra_data"]
         if match_resource_extra_data:
             resource = project.codebaseresources.get(path=match_resource["path"])


### PR DESCRIPTION
This PR adds a check to only process matches for files in `create_packages_from_match_results`. 