### PR TITLE
initial push to add clarity-based compliance support

### DIFF
--- a/scanpipe/apps.py
+++ b/scanpipe/apps.py
@@ -39,6 +39,7 @@ from licensedcode.models import load_licenses
 
 from scanpipe.policies import load_policies_file
 from scanpipe.policies import make_license_policy_index
+from scanpipe.policies import make_clarity_policy_index
 
 try:
     from importlib import metadata as importlib_metadata
@@ -218,7 +219,7 @@ class ScanPipeConfig(AppConfig):
 
     def set_policies(self):
         """
-        Compute and sets the `license_policies` on the app instance.
+        Compute and sets the `license_policies` and `clarity_policies` on the app instance.
 
         If the policies file is available but not formatted properly or doesn't
         include the proper content, we want to raise an exception while the app
@@ -233,8 +234,7 @@ class ScanPipeConfig(AppConfig):
             policies = load_policies_file(policies_file)
             logger.debug(style.SUCCESS(f"Loaded policies from {policies_file}"))
             self.license_policies_index = make_license_policy_index(policies)
-        else:
-            logger.debug(style.WARNING("Policies file not found."))
+            self.clarity_policies_index = make_clarity_policy_index(policies) 
 
     def sync_runs_and_jobs(self):
         """Synchronize ``QUEUED`` and ``RUNNING`` Run with their related Jobs."""

--- a/scanpipe/pipes/compliance.py
+++ b/scanpipe/pipes/compliance.py
@@ -26,6 +26,7 @@ from scanpipe.models import PACKAGE_URL_FIELDS
 from scanpipe.models import ComplianceAlertMixin
 from scanpipe.pipes import flag
 from scanpipe.pipes import scancode
+from scanpipe import policies
 
 """
 A common compliance pattern for images is to store known licenses in a /licenses
@@ -123,3 +124,19 @@ def get_project_compliance_alerts(project, fail_level="error"):
     }
 
     return project_compliance_alerts
+
+def add_clarity_compliance_to_summary(summary, project):
+    """
+    Add clarity compliance alert to summary data.
+    Called from make_results_summary function.
+    """
+    
+    clarity_score = summary.get("license_clarity_score", {}).get("score")
+    if clarity_score is None:
+        return summary
+    
+    clarity_policies = project.clarity_policy_index
+    clarity_compliance = policies.evaluate_clarity_compliance(clarity_score, clarity_policies)
+    
+    summary["clarity_compliance_alert"] = clarity_compliance
+    return summary

--- a/scanpipe/pipes/scancode.py
+++ b/scanpipe/pipes/scancode.py
@@ -934,6 +934,7 @@ def make_results_summary(project, scan_results_location):
     """
     from scanpipe.api.serializers import CodebaseResourceSerializer
     from scanpipe.api.serializers import DiscoveredPackageSerializer
+    from scanpipe import policies
 
     with open(scan_results_location) as f:
         scan_data = json.load(f)
@@ -963,5 +964,11 @@ def make_results_summary(project, scan_results_location):
     summary["key_files_packages"] = [
         DiscoveredPackageSerializer(package).data for package in key_files_packages_qs
     ]
+
+    clarity_score = summary.get("license_clarity_score", {}).get("score")
+    if clarity_score is not None:
+        clarity_policies = project.clarity_policy_index
+        clarity_compliance = policies.evaluate_clarity_compliance(clarity_score, clarity_policies)
+        summary["clarity_compliance_alert"] = clarity_compliance
 
     return summary


### PR DESCRIPTION
This PR adds support for evaluating license clarity scores against compliance policies. Now threshold-based policies for license clarity scores can be defined.

I've extended the policy system to handle both license and clarity policies in the same `policies.yml` file and updated the summary generation to evaluate clarity scores against defined thresholds. Now a `clarity_compliance_alert` field is injected into the summary output based on the evaluation results. Policies can be setup, like requiring a minimum clarity score of 95, with anything below triggering an error alert.

This only works with the `scan_single_package` pipeline since that's the only one that generates clarity scores. The compliance alerts will show up in the summary.json file.
