### PR TITLE
Add support for using Package URL (purl) as project input.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,10 @@ Changelog
 v34.12.0 (unreleased)
 ---------------------
 
+- Add support for using Package URL (purl) as project input.
+  This implementation is based on ``purl2url.get_download_url``.
+  https://github.com/aboutcode-org/scancode.io/issues/1383
+
 - Raise a ``MatchCodeIOException`` when the response from the MatchCode.io service is
   not valid in ``send_project_json_to_matchcode``.
   This generally means an issue on the MatchCode.io server side.

--- a/scanpipe/forms.py
+++ b/scanpipe/forms.py
@@ -64,16 +64,17 @@ class InputsBaseForm(forms.Form):
         label="Download URLs",
         required=False,
         help_text=(
-            "Provide one or more URLs to download, one per line. "
-            "Files are fetched at the beginning of the pipeline run execution."
+            "Enter one or more download URLs, one per line. "
+            "Files will be fetched when the pipeline starts."
         ),
         widget=forms.Textarea(
             attrs={
                 "class": "textarea is-dynamic",
-                "rows": 2,
+                "rows": 3,
                 "placeholder": (
                     "https://domain.com/archive.zip\n"
-                    "docker://docker-reference (e.g.: docker://postgres:13)"
+                    "docker://docker-reference (e.g.: docker://postgres:13)\n"
+                    "pkg://type/name@version"
                 ),
             },
         ),

--- a/scanpipe/tests/__init__.py
+++ b/scanpipe/tests/__init__.py
@@ -101,6 +101,16 @@ def make_message(project, **data):
     )
 
 
+def make_mock_response(url, content=b"\x00", status_code=200, headers=None):
+    """Return a mock HTTP response object for testing purposes."""
+    response = mock.Mock()
+    response.url = url
+    response.content = content
+    response.status_code = status_code
+    response.headers = headers or {}
+    return response
+
+
 resource_data1 = {
     "path": "notice.NOTICE",
     "type": "file",

--- a/scanpipe/tests/pipes/test_fetch.py
+++ b/scanpipe/tests/pipes/test_fetch.py
@@ -29,6 +29,7 @@ from django.test import override_settings
 from requests import auth as request_auth
 
 from scanpipe.pipes import fetch
+from scanpipe.tests import make_mock_response
 
 
 class ScanPipeFetchPipesTest(TestCase):
@@ -71,25 +72,19 @@ class ScanPipeFetchPipesTest(TestCase):
     def test_scanpipe_pipes_fetch_http(self, mock_get):
         url = "https://example.com/filename.zip"
 
-        mock_get.return_value = mock.Mock(
-            content=b"\x00", headers={}, status_code=200, url=url
-        )
+        mock_get.return_value = make_mock_response(url=url)
         downloaded_file = fetch.fetch_http(url)
         self.assertTrue(Path(downloaded_file.directory, "filename.zip").exists())
 
         url_with_spaces = "https://example.com/space%20in%20name.zip"
-        mock_get.return_value = mock.Mock(
-            content=b"\x00", headers={}, status_code=200, url=url_with_spaces
-        )
+        mock_get.return_value = make_mock_response(url=url_with_spaces)
         downloaded_file = fetch.fetch_http(url)
         self.assertTrue(Path(downloaded_file.directory, "space in name.zip").exists())
 
         headers = {
             "content-disposition": 'attachment; filename="another_name.zip"',
         }
-        mock_get.return_value = mock.Mock(
-            content=b"\x00", headers=headers, status_code=200, url=url
-        )
+        mock_get.return_value = make_mock_response(url=url, headers=headers)
         downloaded_file = fetch.fetch_http(url)
         self.assertTrue(Path(downloaded_file.directory, "another_name.zip").exists())
 
@@ -188,9 +183,7 @@ class ScanPipeFetchPipesTest(TestCase):
             "https://example.com/archive.tar.gz",
         ]
 
-        mock_get.return_value = mock.Mock(
-            content=b"\x00", headers={}, status_code=200, url="mocked_url"
-        )
+        mock_get.return_value = make_mock_response(url="mocked_url")
         downloads, errors = fetch.fetch_urls(urls)
         self.assertEqual(2, len(downloads))
         self.assertEqual(urls[0], downloads[0].uri)

--- a/scanpipe/tests/test_commands.py
+++ b/scanpipe/tests/test_commands.py
@@ -48,6 +48,7 @@ from scanpipe.models import Run
 from scanpipe.models import WebhookSubscription
 from scanpipe.pipes import flag
 from scanpipe.pipes import purldb
+from scanpipe.tests import make_mock_response
 from scanpipe.tests import make_package
 from scanpipe.tests import make_project
 from scanpipe.tests import make_resource_file
@@ -963,12 +964,7 @@ class ScanPipeManagementCommandTest(TestCase):
         mock_get_latest_output.return_value = (
             self.data / "scancode" / "is-npm-1.0.0_summary.json"
         )
-        mock_download_get.return_value = mock.Mock(
-            content=b"\x00",
-            headers={},
-            status_code=200,
-            url=download_url,
-        )
+        mock_download_get.return_value = make_mock_response(url=download_url)
 
         self.assertFalse(WebhookSubscription.objects.exists())
 
@@ -1016,12 +1012,7 @@ class ScanPipeManagementCommandTest(TestCase):
             "status": f"updated scannable_uri {scannable_uri_uuid} "
             "scan_status to 'failed'"
         }
-        mock_download_get.return_value = mock.Mock(
-            content=b"\x00",
-            headers={},
-            status_code=200,
-            url=download_url,
-        )
+        mock_download_get.return_value = make_mock_response(url=download_url)
 
         options = [
             "--max-loops",
@@ -1075,18 +1066,8 @@ class ScanPipeManagementCommandTest(TestCase):
         ]
 
         mock_download_get.side_effect = [
-            mock.Mock(
-                content=b"\x00",
-                headers={},
-                status_code=200,
-                url=download_url1,
-            ),
-            mock.Mock(
-                content=b"\x00",
-                headers={},
-                status_code=200,
-                url=download_url2,
-            ),
+            make_mock_response(url=download_url1),
+            make_mock_response(url=download_url2),
         ]
 
         mock_request_post.side_effect = [

--- a/scanpipe/tests/test_models.py
+++ b/scanpipe/tests/test_models.py
@@ -78,6 +78,7 @@ from scanpipe.tests import dependency_data2
 from scanpipe.tests import license_policies_index
 from scanpipe.tests import make_dependency
 from scanpipe.tests import make_message
+from scanpipe.tests import make_mock_response
 from scanpipe.tests import make_package
 from scanpipe.tests import make_project
 from scanpipe.tests import make_resource_directory
@@ -1473,9 +1474,7 @@ class ScanPipeModelsTest(TestCase):
     @mock.patch("requests.sessions.Session.get")
     def test_scanpipe_input_source_model_fetch(self, mock_get):
         download_url = "https://download.url/file.zip"
-        mock_get.return_value = mock.Mock(
-            content=b"\x00", headers={}, status_code=200, url=download_url
-        )
+        mock_get.return_value = make_mock_response(url=download_url)
 
         input_source = self.project1.add_input_source(download_url=download_url)
         destination = input_source.fetch()

--- a/scanpipe/tests/test_pipelines.py
+++ b/scanpipe/tests/test_pipelines.py
@@ -53,6 +53,7 @@ from scanpipe.pipes import output
 from scanpipe.pipes import scancode
 from scanpipe.pipes.input import copy_input
 from scanpipe.tests import FIXTURES_REGEN
+from scanpipe.tests import make_mock_response
 from scanpipe.tests import make_package
 from scanpipe.tests import make_project
 from scanpipe.tests import package_data1
@@ -226,9 +227,7 @@ class ScanPipePipelinesTest(TestCase):
         self.assertEqual("", run.log)
 
         download_url = "https://download.url/file.zip"
-        mock_get.return_value = mock.Mock(
-            content=b"\x00", headers={}, status_code=200, url=download_url
-        )
+        mock_get.return_value = make_mock_response(url=download_url)
         input_source2 = project1.add_input_source(download_url=download_url)
         pipeline.download_missing_inputs()
         self.assertIn("Fetching input from https://download.url/file.zip", run.log)

--- a/setup.cfg
+++ b/setup.cfg
@@ -76,7 +76,7 @@ install_requires =
     extractcode[full]==31.0.0
     commoncode==32.2.1
     Beautifulsoup4[chardet]==4.13.3
-    packageurl-python==0.16.0
+    packageurl-python==0.17.1
     # FetchCode
     fetchcode-container==1.2.3.210512; sys_platform == "linux"
     # Inspectors


### PR DESCRIPTION
#1383

This implementation is based on ``purl2url.get_download_url``.
