### PR TITLE
Catch NotImplementedError

### DIFF
--- a/scanpipe/pipes/purldb.py
+++ b/scanpipe/pipes/purldb.py
@@ -318,8 +318,12 @@ def get_unique_unresolved_purls(project):
 
             try:
                 vers = range_class.from_native(extracted_requirement)
-            except (InvalidVersionRange, InvalidVersion) as exception:
-                if exception is InvalidVersionRange:
+            except (
+                InvalidVersionRange,
+                InvalidVersion,
+                NotImplementedError,
+            ) as exception:
+                if exception in (InvalidVersionRange, NotImplementedError):
                     description = "Version range is invalid or unsupported"
                 else:
                     description = "Extracted requirement is not a valid version"


### PR DESCRIPTION
In the case where we encounter the `NotImplementedError` exception, we now catch it and properly log the error in the project. 