### PR TITLE
[CRAVEX] SCA Integrations: OWASP dep-scan

### DIFF
--- a/.github/workflows/sca-integration-depscan.yml
+++ b/.github/workflows/sca-integration-depscan.yml
@@ -1,0 +1,43 @@
+name: Generate SBOM with OWASP dep-scan and load into ScanCode.io
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - main
+permissions:
+  contents: read
+
+env:
+  IMAGE_REFERENCE: "python:3.13.0-slim"
+
+jobs:
+  generate-and-load-sbom:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Generate SBOM with OWASP dep-scan
+        run: |
+          docker run --rm -v $PWD:/app \
+            ghcr.io/owasp-dep-scan/dep-scan depscan \
+            --src ${{ env.IMAGE_REFERENCE }} \
+            --reports-dir /app/reports \
+            --report-name depscan-sbom.cdx.json
+
+      - name: Upload SBOM as GitHub Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: depscan-sbom
+          path: "$PWD/reports/depscan-sbom.cdx.json"
+          retention-days: 20
+
+#      - name: Import SBOM into ScanCode.io
+#        uses: aboutcode-org/scancode-action@main
+#        with:
+#          pipelines: "load_sbom"
+#          inputs-path: "depscan-sbom.cdx.json"
+#
+#      - name: Verify SBOM Analysis Results in ScanCode.io
+#        shell: bash
+#        run: |
+#          scanpipe shell --command "from scanpipe.models import DiscoveredPackage, DiscoveredDependency; package_manager = DiscoveredPackage.objects; assert package_manager.count() > 340; assert package_manager.vulnerable().count() == 0; assert DiscoveredDependency.objects.count() == 0"


### PR DESCRIPTION
- Issue: https://github.com/aboutcode-org/scancode.io/issues/1733

This PR adds support for importing SBOMs generated with [OWASP dep-scan](https://owasp.org/www-project-dep-scan/).