### PR TITLE
add path breadcrumbs and copy-to-clipboard button in resource_table_view

### DIFF
--- a/scanpipe/templates/scanpipe/panels/resource_table_panel.html
+++ b/scanpipe/templates/scanpipe/panels/resource_table_panel.html
@@ -1,4 +1,23 @@
 {% load humanize %}
+<div class="mb-4">
+  <div class="has-text-weight-semibold is-flex is-align-items-center is-family-monospace">
+    {% if path_segments %}
+      <span id="resource-path" class="has-text-weight-medium">
+        {% for subpath, segment in path_segments %}
+          {% if not forloop.first %}<span class="mx-1">/</span>{% endif %}
+          {% if not forloop.last %}
+            <a href="#" class="expand-in-tree has-text-link" data-path="{{ subpath }}" hx-get="{% url 'codebase_resource_table' project.slug %}?path={{ subpath }}" hx-target="#right-pane">{{ segment }}</a>
+          {% else %}
+            <span>{{ segment }}</span>
+          {% endif %}
+        {% endfor %}
+      </span>
+      <button class="copy-to-clipboard ml-2 is-size-6 is-shadowless is-white" aria-label="Copy path" data-copy="{{ path }}" data-copy-feedback="Path copied!">
+        <i class="fa-regular fa-copy"></i>
+      </button>
+    {% endif %}
+  </div>
+</div>
 
 {% if resources %}
   <table class="table is-bordered is-striped is-narrow is-fullwidth">

--- a/scanpipe/templates/scanpipe/panels/resource_table_panel.html
+++ b/scanpipe/templates/scanpipe/panels/resource_table_panel.html
@@ -3,14 +3,7 @@
   <div class="has-text-weight-semibold is-flex is-align-items-center is-family-monospace">
     {% if path_segments %}
       <span id="resource-path" class="has-text-weight-medium">
-        {% for subpath, segment in path_segments %}
-          {% if not forloop.first %}<span class="mx-1">/</span>{% endif %}
-          {% if not forloop.last %}
-            <a href="#" class="expand-in-tree has-text-link" data-path="{{ subpath }}" hx-get="{% url 'codebase_resource_table' project.slug %}?path={{ subpath }}" hx-target="#right-pane">{{ segment }}</a>
-          {% else %}
-            <span>{{ segment }}</span>
-          {% endif %}
-        {% endfor %}
+        {% for subpath, segment in path_segments %}{% if not forloop.first %}/{% endif %}{% if not forloop.last %}<a href="#" class="expand-in-tree has-text-link" data-path="{{ subpath }}" hx-get="{% url 'codebase_resource_table' project.slug %}?path={{ subpath }}" hx-target="#right-pane">{{ segment }}</a>{% else %}<span>{{ segment }}</span>{% endif %}{% endfor %}
       </span>
       <button class="copy-to-clipboard ml-2 is-size-6 is-shadowless is-white" aria-label="Copy path" data-copy="{{ path }}" data-copy-feedback="Path copied!">
         <i class="fa-regular fa-copy"></i>
@@ -19,82 +12,84 @@
   </div>
 </div>
 
-{% if resources %}
-  <table class="table is-bordered is-striped is-narrow is-fullwidth">
-    <thead class="is-sticky">
-        <tr>
-          <th>Name</th>
-          <th>Status</th>
-          <th>Language</th>
-          <th>License</th>
-          <th>Alert</th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for resource in resources %}
+<div class="table-scroll-area">
+  {% if resources %}
+    <table class="table is-bordered is-striped is-narrow is-fullwidth">
+      <thead class="is-sticky">
           <tr>
-            <td class="is-flex is-align-items-center break-all" style="min-width: 100px;">
-                <span class="icon is-small mr-2">
-                  {% if resource.is_dir %}
-                    <i class="fas fa-folder"></i>
-                  {% else %}
-                    <i class="far fa-file"></i>
-                  {% endif %}
-                </span>
-                {% if resource.is_dir %}
-                  <a href="#" class="expand-in-tree" data-path="{{ resource.path }}" hx-get="{% url 'codebase_resource_table' project.slug %}?path={{ resource.path }}" hx-target="#right-pane">{{ resource.name }}</a>
-                {% else %}
-                  <a href="{% url 'resource_detail' project.slug resource.path %}">{{ resource.name }}</a>
-                {% endif %}
-                {% if resource.tag %}
-                  <span class="tag is-rounded ml-2">{{ resource.tag }}</span>
-                {% endif %}
-            </td>
-            <td>
-              {{ resource.status }}
-            </td>
-            <td class="break-all">
-              {{ resource.programming_language }}
-            </td>
-            <td>
-              {{ resource.detected_license_expression }}
-            </td>
-            <td>
-              {{ resource.compliance_alert }}
-            </td>
+            <th>Name</th>
+            <th>Status</th>
+            <th>Language</th>
+            <th>License</th>
+            <th>Alert</th>
           </tr>
-        {% endfor %}
-      </tbody>
-  </table>
+        </thead>
+        <tbody>
+          {% for resource in resources %}
+            <tr>
+              <td class="is-flex is-align-items-center break-all" style="min-width: 100px;">
+                  <span class="icon is-small mr-2">
+                    {% if resource.is_dir %}
+                      <i class="fas fa-folder"></i>
+                    {% else %}
+                      <i class="far fa-file"></i>
+                    {% endif %}
+                  </span>
+                  {% if resource.is_dir %}
+                    <a href="#" class="expand-in-tree" data-path="{{ resource.path }}" hx-get="{% url 'codebase_resource_table' project.slug %}?path={{ resource.path }}" hx-target="#right-pane">{{ resource.name }}</a>
+                  {% else %}
+                    <a href="{% url 'resource_detail' project.slug resource.path %}">{{ resource.name }}</a>
+                  {% endif %}
+                  {% if resource.tag %}
+                    <span class="tag is-rounded ml-2">{{ resource.tag }}</span>
+                  {% endif %}
+              </td>
+              <td>
+                {{ resource.status }}
+              </td>
+              <td class="break-all">
+                {{ resource.programming_language }}
+              </td>
+              <td>
+                {{ resource.detected_license_expression }}
+              </td>
+              <td>
+                {{ resource.compliance_alert }}
+              </td>
+            </tr>
+          {% endfor %}
+        </tbody>
+    </table>
 
-  {% if is_paginated %}
-    <nav class="pagination is-centered mt-4" role="navigation">
-      {% if page_obj.has_previous %}
-        <a class="pagination-previous" hx-get="{% url 'codebase_resource_table' project.slug %}?path={{ path }}&page={{ page_obj.previous_page_number }}" hx-target="#right-pane">Previous</a>
-      {% endif %}
-      {% if page_obj.has_next %}
-        <a class="pagination-next" hx-get="{% url 'codebase_resource_table' project.slug %}?path={{ path }}&page={{ page_obj.next_page_number }}" hx-target="#right-pane">Next page</a>
-      {% endif %}
-      <ul class="pagination-list">
-        <li>
-          <span class="pagination-ellipsis">
-            Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}
-          </span>
-        </li>
-      </ul>
-    </nav>
-  {% endif %}
-{% else %}
-  <div class="has-text-centered p-6">
-    <div class="icon is-large has-text-grey-light mb-3">
-      <i class="fas fa-folder-open fa-3x"></i>
+    {% if is_paginated %}
+      <nav class="pagination is-centered mt-4" role="navigation">
+        {% if page_obj.has_previous %}
+          <a class="pagination-previous" hx-get="{% url 'codebase_resource_table' project.slug %}?path={{ path }}&page={{ page_obj.previous_page_number }}" hx-target="#right-pane">Previous</a>
+        {% endif %}
+        {% if page_obj.has_next %}
+          <a class="pagination-next" hx-get="{% url 'codebase_resource_table' project.slug %}?path={{ path }}&page={{ page_obj.next_page_number }}" hx-target="#right-pane">Next page</a>
+        {% endif %}
+        <ul class="pagination-list">
+          <li>
+            <span class="pagination-ellipsis">
+              Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}
+            </span>
+          </li>
+        </ul>
+      </nav>
+    {% endif %}
+  {% else %}
+    <div class="has-text-centered p-6">
+      <div class="icon is-large has-text-grey-light mb-3">
+        <i class="fas fa-folder-open fa-3x"></i>
+      </div>
+      <p class="has-text-grey">
+        {% if path %}
+          No resources found in this directory.
+        {% else %}
+          Select a file or folder from the tree to view its contents.
+        {% endif %}
+      </p>
     </div>
-    <p class="has-text-grey">
-      {% if path %}
-        No resources found in this directory.
-      {% else %}
-        Select a file or folder from the tree to view its contents.
-      {% endif %}
-    </p>
-  </div>
-{% endif %}
+  {% endif %}
+</div>

--- a/scanpipe/templates/scanpipe/panels/resource_table_panel.html
+++ b/scanpipe/templates/scanpipe/panels/resource_table_panel.html
@@ -3,7 +3,16 @@
   <div class="has-text-weight-semibold is-flex is-align-items-center is-family-monospace">
     {% if path_segments %}
       <span id="resource-path" class="has-text-weight-medium">
-        {% for subpath, segment in path_segments %}{% if not forloop.first %}/{% endif %}{% if not forloop.last %}<a href="#" class="expand-in-tree has-text-link" data-path="{{ subpath }}" hx-get="{% url 'codebase_resource_table' project.slug %}?path={{ subpath }}" hx-target="#right-pane">{{ segment }}</a>{% else %}<span>{{ segment }}</span>{% endif %}{% endfor %}
+        {% spaceless %}
+        {% for subpath, segment in path_segments %}
+          {% if not forloop.first %}<span class="mx-1">/</span>{% endif %}
+          {% if not forloop.last %}
+            <a href="#" class="expand-in-tree has-text-link" data-path="{{ subpath }}" hx-get="{% url 'codebase_resource_table' project.slug %}?path={{ subpath }}" hx-target="#right-pane">{{ segment }}</a>
+          {% else %}
+            <span>{{ segment }}</span>
+          {% endif %}
+        {% endfor %}
+        {% endspaceless %}
       </span>
       <button class="copy-to-clipboard ml-2 is-size-6 is-shadowless is-white" aria-label="Copy path" data-copy="{{ path }}" data-copy-feedback="Path copied!">
         <i class="fa-regular fa-copy"></i>

--- a/scanpipe/templates/scanpipe/resource_tree.html
+++ b/scanpipe/templates/scanpipe/resource_tree.html
@@ -105,6 +105,14 @@
 
 {% block scripts %}
   <script>
+    document.body.addEventListener('htmx:afterSwap', function(evt) {
+      if (evt.target && evt.target.id === 'right-pane') {
+        if (typeof enableCopyToClipboard === 'function') {
+          enableCopyToClipboard('.copy-to-clipboard');
+        }
+      }
+    });
+    
     // Tree functionality
     document.addEventListener("click", async function (e) {
       const chevron = e.target.closest("[data-chevron]");

--- a/scanpipe/templates/scanpipe/resource_tree.html
+++ b/scanpipe/templates/scanpipe/resource_tree.html
@@ -54,10 +54,16 @@
     }
     .right-pane {
       flex: 1;
-      overflow-y: auto;
-      overflow-x: hidden;
       min-width: 0;
       transition: opacity 0.2s ease;
+      display: flex;
+      flex-direction: column;
+      height: 100%;
+    }
+    .right-pane .table-scroll-area {
+      flex: 1;
+      overflow-y: auto;
+      overflow-x: hidden;
     }
     .right-pane.collapsed {
       opacity: 0;

--- a/scanpipe/views.py
+++ b/scanpipe/views.py
@@ -2837,5 +2837,8 @@ class CodebaseResourceTableView(
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context["path"] = self.request.GET.get("path", "")
+        path = self.request.GET.get("path", "")
+        context["path"] = path
+        segments = path.strip("/").split("/")
+        context["path_segments"] = [ ("/".join(segments[:i+1]), segment) for i, segment in enumerate(segments) ]
         return context

--- a/scanpipe/views.py
+++ b/scanpipe/views.py
@@ -2840,5 +2840,7 @@ class CodebaseResourceTableView(
         path = self.request.GET.get("path", "")
         context["path"] = path
         segments = path.strip("/").split("/")
-        context["path_segments"] = [ ("/".join(segments[:i+1]), segment) for i, segment in enumerate(segments) ]
+        context["path_segments"] = [
+            ("/".join(segments[: i + 1]), segment) for i, segment in enumerate(segments)
+        ]
         return context


### PR DESCRIPTION
Reference #1840 

- Added a path display at the top of resource_table_view, which also serves as breadcrumbs for navigating to parent directories.
- Added a Copy to Clipboard button that copies the current path.


<img width="1898" height="917" alt="image" src="https://github.com/user-attachments/assets/46395807-3b18-4175-81f5-2bd50975c3e2" />
