### PR TITLE
fix: make the input location optional in the run command

### DIFF
--- a/docs/command-line-interface.rst
+++ b/docs/command-line-interface.rst
@@ -759,8 +759,8 @@ Optional arguments:
 
 .. _cli_run:
 
-`$ run PIPELINE_NAME [PIPELINE_NAME ...] input_location`
---------------------------------------------------------
+`$ run PIPELINE_NAME [PIPELINE_NAME ...] [input_location]`
+----------------------------------------------------------
 
 A ``run`` command is available for executing pipelines and printing the results
 without providing any configuration. This can be useful for running a pipeline to get
@@ -769,6 +769,9 @@ review the results.
 
 .. tip:: You can run multiple pipelines by providing their names, space-separated,
   such as `pipeline1 pipeline2`.
+
+The ``input_location`` is optional, so pipelines that do not take any input can be
+run without it.
 
 Optional arguments:
 

--- a/scanpipe/management/commands/run.py
+++ b/scanpipe/management/commands/run.py
@@ -23,6 +23,7 @@
 from collections import defaultdict
 from pathlib import Path
 
+from django.apps import apps
 from django.core.management import call_command
 from django.core.management.base import BaseCommand
 from django.core.management.base import CommandError
@@ -30,6 +31,8 @@ from django.utils.crypto import get_random_string
 
 from scanpipe.management.commands import extract_tag_from_input_file
 from scanpipe.pipes.fetch import SCHEME_TO_FETCHER_MAPPING
+
+scanpipe_app = apps.get_app_config("scanpipe")
 
 
 class Command(BaseCommand):
@@ -50,9 +53,11 @@ class Command(BaseCommand):
         )
         parser.add_argument(
             "input_location",
+            nargs="?",
             help=(
                 "Input location: file, directory, and URL supported."
-                'Multiple values can be provided using the "input1,input2" syntax.'
+                'Multiple values can be provided using the "input1,input2" syntax. '
+                "Optional, as some pipelines do not require any input."
             ),
         )
         parser.add_argument("--project", required=False, help="Project name.")
@@ -64,8 +69,14 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
+        # The ``input_location`` positional is declared for the command usage, but
+        # argparse collects every positional value in ``pipelines``. The trailing
+        # value is the input location unless it is an available pipeline name.
         pipelines = options["pipelines"]
-        input_location = options["input_location"]
+        input_location = None
+        if len(pipelines) > 1 and not self.is_pipeline_name(pipelines[-1]):
+            input_location = pipelines.pop()
+
         output_format = options["format"]
         # Generate a random name for the project if not provided
         project_name = options["project"] or get_random_string(10)
@@ -74,8 +85,9 @@ class Command(BaseCommand):
             "pipeline": pipelines,
             "execute": True,
             "verbosity": 0,
-            **self.get_input_options(input_location),
         }
+        if input_location:
+            create_project_options.update(self.get_input_options(input_location))
 
         # Run the database migrations in case the database is not created or outdated.
         call_command("migrate", verbosity=0, interactive=False)
@@ -83,6 +95,13 @@ class Command(BaseCommand):
         call_command("create-project", project_name, **create_project_options)
         # Print the results for the specified format on stdout
         call_command("output", project=project_name, format=[output_format], print=True)
+
+    @staticmethod
+    def is_pipeline_name(value):
+        """Return True when the provided ``value`` is an available pipeline name."""
+        pipeline_name, _ = scanpipe_app.extract_group_from_pipeline(value)
+        pipeline_name = scanpipe_app.get_new_pipeline_name(pipeline_name)
+        return pipeline_name in scanpipe_app.pipelines
 
     @staticmethod
     def get_input_options(input_location):

--- a/scanpipe/tests/test_commands.py
+++ b/scanpipe/tests/test_commands.py
@@ -1007,9 +1007,7 @@ class ScanPipeManagementCommandTest(TestCase):
         self.assertTrue(user.is_superuser)
 
     def test_scanpipe_management_command_run(self):
-        expected = (
-            "Error: the following arguments are required: PIPELINE_NAME, input_location"
-        )
+        expected = "Error: the following arguments are required: PIPELINE_NAME"
         with self.assertRaisesMessage(CommandError, expected):
             call_command("run")
 
@@ -1046,6 +1044,29 @@ class ScanPipeManagementCommandTest(TestCase):
 
         self.assertEqual("do_nothing", runs[1]["pipeline_name"])
         self.assertEqual(["Group1", "Group2"], runs[1]["selected_groups"])
+
+    def test_scanpipe_management_command_run_without_input_location(self):
+        out = StringIO()
+        with redirect_stdout(out):
+            call_command("run", "do_nothing")
+
+        json_data = json.loads(out.getvalue())
+        self.assertEqual([], json_data["files"])
+        runs = json_data["headers"][0]["runs"]
+        self.assertEqual(1, len(runs))
+        self.assertEqual("do_nothing", runs[0]["pipeline_name"])
+        self.assertEqual("success", runs[0]["status"])
+
+        # A trailing pipeline name is not mistaken for an input location
+        out = StringIO()
+        with redirect_stdout(out):
+            call_command("run", "do_nothing", "profile_step")
+
+        json_data = json.loads(out.getvalue())
+        runs = json_data["headers"][0]["runs"]
+        self.assertEqual(2, len(runs))
+        self.assertEqual("do_nothing", runs[0]["pipeline_name"])
+        self.assertEqual("profile_step", runs[1]["pipeline_name"])
 
     @mock.patch("scanpipe.pipes.fetch.is_safe_url", return_value=True)
     @mock.patch("scanpipe.pipes.fetch.check_url")


### PR DESCRIPTION
## Issues

- Closes: #2203

## Changes

The `run` command always required an input location, so a pipeline that takes no input could only be started with `run <pipeline> ""`.

`input_location` is now declared with `nargs="?"`. Since argparse gives every positional value to the `nargs="+"` pipelines list, the trailing value is moved to `input_location` only when it is not an available pipeline name. The input options are built only when a location was given, so a pipeline that does need an input fails during its own execution instead of at argument parsing.

Added a test that runs a pipeline with no input and checks that a trailing pipeline name is not read as an input location. Updated the existing test for the new "arguments are required" message, and the CLI docs.

I could not run the Django test suite locally, since it needs the Docker and PostgreSQL stack. I ran `ruff check`, `ruff format --check`, `doc8` on the changed docs page, and a standalone script that replays the positional split for every `run` invocation used in the existing tests.

AI disclosure: I used Claude Code while writing this patch.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/aboutcode-org/scancode.io/blob/main/CONTRIBUTING.md)
- [x] I have linked an existing issue above
- [x] I have added unit tests covering the new code
- [x] I have reviewed and understood every line of this PR