### PR TITLE
fix: serve JSON and text downloads inline so they open in the browser

### DIFF
--- a/scanpipe/tests/test_views.py
+++ b/scanpipe/tests/test_views.py
@@ -386,6 +386,18 @@ class ScanPipeViewsTest(TestCase):
             response.headers["Content-Disposition"],
         )
 
+    def test_scanpipe_views_project_details_download_output_view_json_inline(self):
+        # https://github.com/aboutcode-org/scancode.io/issues/2210
+        json_file = self.project1.output_path / "results.json"
+        json_file.write_text('{"headers": []}')
+        url = reverse("project_download_output", args=[self.project1.slug, "results.json"])
+        response = self.client.get(url)
+        self.assertEqual("application/json", response.headers["Content-Type"])
+        self.assertEqual(
+            'inline; filename="results.json"',
+            response.headers["Content-Disposition"],
+        )
+
     def test_scanpipe_views_project_details_delete_input_view(self):
         random_uuid = str(uuid.uuid4())
         url = reverse("project_delete_input", args=[self.project1.slug, random_uuid])

--- a/scanpipe/views.py
+++ b/scanpipe/views.py
@@ -1532,7 +1532,11 @@ def download_project_file(request, slug, filename, path_type):
     if not file_path.exists():
         raise Http404(f"{file_path} not found")
 
-    return FileResponse(file_path.open("rb"), as_attachment=True)
+    # JSON and plain text render safely in browsers: serve those inline so
+    # that e.g. JSON results open directly in the browser instead of always
+    # forcing a download.
+    as_attachment = file_path.suffix not in (".json", ".txt")
+    return FileResponse(file_path.open("rb"), as_attachment=as_attachment)
 
 
 @conditional_login_required


### PR DESCRIPTION
Closes #2210

`download_project_file()` forced `as_attachment=True` for every input and output file, so a JSON output always became a separate download. This serves `.json` and `.txt` files inline instead -- `FileResponse` then also sets the proper content type from the filename (`application/json` / `text/plain`), so they open directly in the browser; all other formats keep forcing a download.

One deliberate scoping choice: `.html` (e.g. generated attribution documents) is *not* served inline, since those embed data derived from scanned third-party packages and rendering them in the app origin would be an XSS vector. Happy to extend the inline set if you prefer.

Tested with the existing download view tests plus a new one asserting `Content-Type: application/json` and `Content-Disposition: inline` for a JSON output (3/3 pass on sqlite locally).
