### PR TITLE
fix: derive dependency package type from the purl in ignored_dependency_scopes filtering

### DIFF
--- a/scanpipe/pipes/__init__.py
+++ b/scanpipe/pipes/__init__.py
@@ -33,6 +33,8 @@ from pathlib import Path
 
 from django.db.models import Count
 
+from packageurl import PackageURL
+
 from scanpipe.models import AbstractTaskFieldsModel
 from scanpipe.models import CodebaseRelation
 from scanpipe.models import CodebaseResource
@@ -250,6 +252,14 @@ def ignore_dependency_scope(project, dependency_data):
         return False
 
     dependency_package_type = dependency_data.get("package_type")
+    if not dependency_package_type:
+        # Dependency data from a scancode-toolkit scan has no "package_type"
+        # entry: derive the type from the purl instead.
+        try:
+            purl = dependency_data.get("purl") or ""
+            dependency_package_type = PackageURL.from_string(purl).type
+        except ValueError:
+            dependency_package_type = None
     dependency_scope = dependency_data.get("scope")
     if dependency_package_type and dependency_scope:
         if dependency_scope in ignored_scope_index.get(dependency_package_type, []):

--- a/scanpipe/tests/pipes/test_pipes.py
+++ b/scanpipe/tests/pipes/test_pipes.py
@@ -236,6 +236,35 @@ class ScanPipePipesTest(TestCase):
         dependency = pipes.update_or_create_dependency(p1, dependency_data)
         self.assertIsNone(dependency)
 
+    def test_scanpipe_pipes_ignore_dependency_scope_package_type_from_purl(self):
+        # https://github.com/aboutcode-org/scancode.io/issues/2215
+        # Dependency data from a scancode-toolkit scan has no "package_type"
+        # entry: the type must be derived from the purl.
+        p1 = Project.objects.create(name="Analysis")
+        p1.settings = {
+            "ignored_dependency_scopes": [
+                {"package_type": "npm", "scope": "devDependencies"}
+            ]
+        }
+        p1.save()
+
+        dependency_data = {
+            "purl": "pkg:npm/mocha@10.2.0",
+            "scope": "devDependencies",
+        }
+        self.assertTrue(pipes.ignore_dependency_scope(p1, dependency_data))
+
+        dependency_data["scope"] = "dependencies"
+        self.assertFalse(pipes.ignore_dependency_scope(p1, dependency_data))
+
+        dependency_data = {"purl": "pkg:pypi/mocha@10.2.0", "scope": "devDependencies"}
+        self.assertFalse(pipes.ignore_dependency_scope(p1, dependency_data))
+
+        # no purl and no package_type: never ignored
+        self.assertFalse(
+            pipes.ignore_dependency_scope(p1, {"scope": "devDependencies"})
+        )
+
     def test_scanpipe_pipes_get_or_create_relation(self):
         p1 = Project.objects.create(name="Analysis")
         from1 = make_resource_file(p1, "from/a.txt")


### PR DESCRIPTION
Closes #2215

`ignore_dependency_scope()` compares the `ignored_dependency_scopes` setting against `dependency_data["package_type"]` -- but dependency data coming from a scancode-toolkit scan has no `package_type` entry, only a `purl`. Since the guard requires both `package_type` and `scope` to be truthy, the filter silently never matched on real scan data, which is exactly the reported behavior: `{package_type: npm, scope: devDependencies}` from the tutorial config not excluding anything.

The fix derives the package type from the purl when the `package_type` entry is absent (`PackageURL.from_string(purl).type`), keeping the explicit entry as the priority when present. The existing test masked the gap by setting `package_type` explicitly on the test data; a new test covers the purl-only shape with matching scope, non-matching scope, non-matching type, and the no-purl/no-type case.

Both the existing and new tests pass locally (sqlite).
