### PR TITLE
restrict the click version to 8.4.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ classifiers = [
 ]
 
 dependencies = [
+  "click==8.4.2",
   "uv==0.11.29",
   "importlib-metadata==9.0.0",
   "setuptools==83.0.0",


### PR DESCRIPTION
## Issues

- Closes: #2219

## Changes

<!-- Describe your changes clearly and concisely. What was fixed, added, or updated? Explain the reasoning behind your approach. -->
Pin `click` to version 8.4.2 because the latest version (8.5.0) introduces some test failures, while these tests pass when using `click` 8.4.2.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/aboutcode-org/scancode.io/blob/main/CONTRIBUTING.md)
- [x] I have linked an existing issue above
- [x] I have added unit tests covering the new code
- [x] I have reviewed and understood every line of this PR
