### PR TITLE
fix: serve files as_attachment only when too large

### DIFF
--- a/scanpipe/settings.py
+++ b/scanpipe/settings.py
@@ -65,6 +65,10 @@ DEFAULTS = {
     # Syntax in .env: SCANCODEIO_GLOBAL_WEBHOOK=target_url=https://webhook.url,
     # trigger_on_each_run=False,include_summary=True,include_results=False
     "GLOBAL_WEBHOOK": {},
+    # Maximum file size, in bytes, served inline in the browser rather than
+    # forced as an attachment download. Above this size, the browser tab
+    # rendering the file (e.g. a large JSON) risks hanging.
+    "INLINE_DOWNLOAD_MAX_SIZE": 10_000_000,
     # Default limit for "most common" entries in QuerySets.
     "MOST_COMMON_LIMIT": 7,
     # Syntax in .env: SCANCODEIO_NETRC_LOCATION="~/.netrc"

--- a/scanpipe/tests/test_views.py
+++ b/scanpipe/tests/test_views.py
@@ -365,6 +365,13 @@ class ScanPipeViewsTest(TestCase):
         self.assertTrue(response.getvalue().startswith(b"# SPDX-License-Identifier"))
         self.assertEqual("application/octet-stream", response.headers["Content-Type"])
         self.assertEqual(
+            'inline; filename="notice.NOTICE"',
+            response.headers["Content-Disposition"],
+        )
+
+        with override_settings(SCANPIPE={"INLINE_DOWNLOAD_MAX_SIZE": 0}):
+            response = self.client.get(url)
+        self.assertEqual(
             'attachment; filename="notice.NOTICE"',
             response.headers["Content-Disposition"],
         )
@@ -381,6 +388,13 @@ class ScanPipeViewsTest(TestCase):
         response = self.client.get(url)
         self.assertTrue(response.getvalue().startswith(b"# SPDX-License-Identifier"))
         self.assertEqual("application/octet-stream", response.headers["Content-Type"])
+        self.assertEqual(
+            'inline; filename="notice.NOTICE"',
+            response.headers["Content-Disposition"],
+        )
+
+        with override_settings(SCANPIPE={"INLINE_DOWNLOAD_MAX_SIZE": 0}):
+            response = self.client.get(url)
         self.assertEqual(
             'attachment; filename="notice.NOTICE"',
             response.headers["Content-Disposition"],

--- a/scanpipe/tests/test_views.py
+++ b/scanpipe/tests/test_views.py
@@ -1505,6 +1505,10 @@ class ScanPipeViewsTest(TestCase):
 
         self.assertIsInstance(response, FileResponse)
         self.assertEqual(response.get("Content-Type"), "application/json")
+        self.assertTrue(response.get("Content-Disposition").startswith("inline"))
+
+        with override_settings(SCANPIPE={"INLINE_DOWNLOAD_MAX_SIZE": 0}):
+            response = self.client.get(url + "?export_json=True")
         self.assertTrue(response.get("Content-Disposition").startswith("attachment"))
 
         file_content = b"".join(response.streaming_content).decode("utf-8")
@@ -1570,7 +1574,7 @@ class ScanPipeViewsTest(TestCase):
 
         self.assertIsInstance(response, FileResponse)
         self.assertEqual(response.get("Content-Type"), "application/json")
-        self.assertTrue(response.get("Content-Disposition").startswith("attachment"))
+        self.assertTrue(response.get("Content-Disposition").startswith("inline"))
 
         file_content = b"".join(response.streaming_content).decode("utf-8")
         json_data = json.loads(file_content)
@@ -1606,7 +1610,7 @@ class ScanPipeViewsTest(TestCase):
 
         self.assertIsInstance(response, FileResponse)
         self.assertEqual(response.get("Content-Type"), "application/json")
-        self.assertTrue(response.get("Content-Disposition").startswith("attachment"))
+        self.assertTrue(response.get("Content-Disposition").startswith("inline"))
 
         file_content = b"".join(response.streaming_content).decode("utf-8")
         json_data = json.loads(file_content)
@@ -1630,7 +1634,7 @@ class ScanPipeViewsTest(TestCase):
 
         self.assertIsInstance(response, FileResponse)
         self.assertEqual(response.get("Content-Type"), "application/json")
-        self.assertTrue(response.get("Content-Disposition").startswith("attachment"))
+        self.assertTrue(response.get("Content-Disposition").startswith("inline"))
 
         file_content = b"".join(response.streaming_content).decode("utf-8")
         json_data = json.loads(file_content)
@@ -1656,7 +1660,7 @@ class ScanPipeViewsTest(TestCase):
 
         self.assertIsInstance(response, FileResponse)
         self.assertEqual(response.get("Content-Type"), "application/json")
-        self.assertTrue(response.get("Content-Disposition").startswith("attachment"))
+        self.assertTrue(response.get("Content-Disposition").startswith("inline"))
 
         file_content = b"".join(response.streaming_content).decode("utf-8")
         json_data = json.loads(file_content)

--- a/scanpipe/views.py
+++ b/scanpipe/views.py
@@ -540,11 +540,13 @@ class ExportJSONMixin:
         serializer = serializer_class(queryset, many=True)
         serialized_data = json.dumps(serializer.data, indent=2, cls=DjangoJSONEncoder)
 
-        output_file = io.BytesIO(serialized_data.encode("utf-8"))
+        encoded_data = serialized_data.encode("utf-8")
+        output_file = io.BytesIO(encoded_data)
+        is_too_large = len(encoded_data) > scanpipe_settings.INLINE_DOWNLOAD_MAX_SIZE
 
         return FileResponse(
             output_file,
-            as_attachment=True,
+            as_attachment=is_too_large,
             filename=self.get_export_json_filename(),
             content_type="application/json",
         )

--- a/scanpipe/views.py
+++ b/scanpipe/views.py
@@ -1532,7 +1532,8 @@ def download_project_file(request, slug, filename, path_type):
     if not file_path.exists():
         raise Http404(f"{file_path} not found")
 
-    return FileResponse(file_path.open("rb"), as_attachment=True)
+    is_too_large = file_path.stat().st_size > scanpipe_settings.INLINE_DOWNLOAD_MAX_SIZE
+    return FileResponse(file_path.open("rb"), as_attachment=is_too_large)
 
 
 @conditional_login_required


### PR DESCRIPTION
## Issues

- Closes: #2210
