### PR TITLE
Fix: detection review ux

### DIFF
--- a/scancodeio/static/main.css
+++ b/scancodeio/static/main.css
@@ -196,6 +196,21 @@ pre.wrap {
 pre.is-small {
   padding: 0.75rem 1rem;
 }
+.license-match-text {
+  max-height: 24rem;
+  overflow: auto;
+}
+.license-match-comparison pre {
+  margin-bottom: 0.75rem;
+}
+.license-match-block {
+  border-top: 1px solid var(--bulma-border-weak);
+  padding-top: 0.75rem;
+}
+.license-match-block:first-child {
+  border-top: 0;
+  padding-top: 0;
+}
 .nexb-orange {
   color: rgb(var(--nexb-orange));
 }

--- a/scanpipe/templates/scanpipe/includes/license_match_comparison.html
+++ b/scanpipe/templates/scanpipe/includes/license_match_comparison.html
@@ -1,0 +1,16 @@
+<div class="license-match-comparison">
+  <div class="columns is-variable is-2 is-multiline mb-0">
+    <div class="column is-half">
+      <p class="has-text-weight-semibold mb-1">Matched text</p>
+      <pre class="wrap is-small license-match-text">{{ match.matched_text|default:"" }}</pre>
+    </div>
+    <div class="column is-half">
+      <p class="has-text-weight-semibold mb-1">Rule text</p>
+      <pre class="wrap is-small license-match-text">{{ match.rule_text|default:"" }}</pre>
+    </div>
+  </div>
+  {% if match.matched_text_diagnostics %}
+    <p class="has-text-weight-semibold mb-1">Diagnostic matched text</p>
+    <pre class="wrap is-small license-match-text">{{ match.matched_text_diagnostics }}</pre>
+  {% endif %}
+</div>

--- a/scanpipe/templates/scanpipe/tabset/tab_license_detections.html
+++ b/scanpipe/templates/scanpipe/tabset/tab_license_detections.html
@@ -1,10 +1,58 @@
 <div class="content">
+    {% if file_match_groups %}
+    <h2 class="is-size-5 mb-3">Matches by file</h2>
+    {% for file_group in file_match_groups %}
+    <article class="box p-3 mb-4">
+      <div class="is-flex is-justify-content-space-between is-align-items-flex-start is-flex-wrap-wrap mb-3">
+        <div class="break-all mr-3">
+          {% if file_group.file_region.path %}
+            <a href="{% url 'resource_detail' project.slug file_group.file_region.path %}#detection">{{ file_group.file_region.path }}</a>
+          {% else %}
+            <span class="has-text-grey">No origin resource path</span>
+          {% endif %}
+        </div>
+        {% if file_group.file_region.start_line or file_group.file_region.end_line %}
+          <div class="tags">
+            <span class="tag">Lines {{ file_group.file_region.start_line }}-{{ file_group.file_region.end_line }}</span>
+          </div>
+        {% endif %}
+      </div>
+      {% if file_group.matches %}
+        {% for match in file_group.matches %}
+          <div class="license-match-block{% if not forloop.last %} mb-4{% endif %}">
+            <div class="tags mb-2">
+              <span class="tag is-dark">{{ match.license_expression }}</span>
+              {% if match.matcher %}<span class="tag">Matcher {{ match.matcher }}</span>{% endif %}
+              {% if match.score %}<span class="tag">Score {{ match.score }}</span>{% endif %}
+              {% if match.match_coverage %}<span class="tag">Coverage {{ match.match_coverage }}</span>{% endif %}
+              {% if match.rule_identifier %}
+                <span class="tag">
+                  {% if match.rule_url %}
+                    <a href="{{ match.rule_url }}">{{ match.rule_identifier }} <i class="fa-solid fa-up-right-from-square is-small"></i></a>
+                  {% else %}
+                    {{ match.rule_identifier }}
+                  {% endif %}
+                </span>
+              {% endif %}
+            </div>
+            {% include "scanpipe/includes/license_match_comparison.html" with match=match only %}
+          </div>
+        {% endfor %}
+      {% else %}
+        <p class="has-text-grey">No match text is available for this file region.</p>
+      {% endif %}
+    </article>
+    {% endfor %}
+    {% endif %}
+
     <table class="table is-bordered is-striped is-narrow is-hoverable is-fullwidth is-rounded-table">
         <thead>
           <tr>
             <th>License expression</th>
             <th>Origin resource path</th>
             <th>Matched text</th>
+            <th>Diagnostic matched text</th>
+            <th>Rule text</th>
             <th>Rule URL</th>
             <th>Score</th>
             <th>Matcher</th>
@@ -24,6 +72,12 @@
             </td>
             <td class="break-all">
               {{ match.matched_text }}
+            </td>
+            <td class="break-all">
+              {{ match.matched_text_diagnostics }}
+            </td>
+            <td class="break-all">
+              {{ match.rule_text }}
             </td>
             <td class="break-all">
               {% if match.rule_url %}

--- a/scanpipe/templates/scanpipe/tabset/tab_resource_detections.html
+++ b/scanpipe/templates/scanpipe/tabset/tab_resource_detections.html
@@ -1,6 +1,6 @@
 <div class="content">
     {% if tab_data.fields.license_detections.value %}
-    <table class="table is-bordered is-striped is-narrow is-hoverable is-fullwidth is-rounded-table">
+    <table class="table is-bordered is-striped is-narrow is-hoverable is-fullwidth is-rounded-table mb-4">
         <thead>
           <tr>
             <th>License detections</th>
@@ -24,6 +24,45 @@
           {% endfor %}
         </tbody>
     </table>
+
+    {% for detection in tab_data.fields.license_detections.value %}
+      <article class="box p-3 mb-4">
+        <div class="is-flex is-justify-content-space-between is-align-items-flex-start is-flex-wrap-wrap mb-3">
+          <div class="break-all mr-3">
+            <a href="{% url 'license_detail' project.slug detection.identifier %}">{{ detection.identifier }}</a>
+          </div>
+          <div class="tags">
+            <span class="tag is-dark">{{ detection.license_expression }}</span>
+            {% if detection.license_expression_spdx %}
+              <span class="tag">{{ detection.license_expression_spdx }}</span>
+            {% endif %}
+          </div>
+        </div>
+        {% for match in detection.matches %}
+          <div class="license-match-block{% if not forloop.last %} mb-4{% endif %}">
+            <div class="tags mb-2">
+              <span class="tag is-dark">{{ match.license_expression }}</span>
+              {% if match.start_line or match.end_line %}<span class="tag">Lines {{ match.start_line }}-{{ match.end_line }}</span>{% endif %}
+              {% if match.matcher %}<span class="tag">Matcher {{ match.matcher }}</span>{% endif %}
+              {% if match.score %}<span class="tag">Score {{ match.score }}</span>{% endif %}
+              {% if match.match_coverage %}<span class="tag">Coverage {{ match.match_coverage }}</span>{% endif %}
+              {% if match.rule_identifier %}
+                <span class="tag">
+                  {% if match.rule_url %}
+                    <a href="{{ match.rule_url }}">{{ match.rule_identifier }} <i class="fa-solid fa-up-right-from-square is-small"></i></a>
+                  {% else %}
+                    {{ match.rule_identifier }}
+                  {% endif %}
+                </span>
+              {% endif %}
+            </div>
+            {% include "scanpipe/includes/license_match_comparison.html" with match=match only %}
+          </div>
+        {% empty %}
+          <p class="has-text-grey">No match text is available for this detection.</p>
+        {% endfor %}
+      </article>
+    {% endfor %}
     {% endif %}
     {% if tab_data.fields.license_clues.value %}
     <table class="table is-bordered is-striped is-narrow is-hoverable is-fullwidth is-rounded-table">

--- a/scanpipe/tests/test_views.py
+++ b/scanpipe/tests/test_views.py
@@ -42,6 +42,7 @@ from scanpipe.forms import BaseProjectActionForm
 from scanpipe.models import CodebaseRelation
 from scanpipe.models import CodebaseResource
 from scanpipe.models import DiscoveredDependency
+from scanpipe.models import DiscoveredLicense
 from scanpipe.models import DiscoveredPackage
 from scanpipe.models import Project
 from scanpipe.pipes import make_relation
@@ -1396,6 +1397,84 @@ class ScanPipeViewsTest(TestCase):
         xss_url = reverse("license_detail", args=[xss])
         response = self.client.get(xss_url)
         self.assertEqual(response.status_code, 404)
+
+    def test_scanpipe_views_license_detection_details_view_match_texts(self):
+        matches = [
+            {
+                "score": 100.0,
+                "start_line": 1,
+                "end_line": 1,
+                "matched_length": 4,
+                "match_coverage": 100.0,
+                "matcher": "1-hash",
+                "license_expression": "mit",
+                "rule_identifier": "mit_1.RULE",
+                "rule_text": "license: MIT",
+                "matched_text": "License: MIT",
+                "matched_text_diagnostics": "License MIT",
+                "from_file": "LICENSE",
+            }
+        ]
+        license_detection = DiscoveredLicense.objects.create(
+            project=self.project1,
+            license_expression="mit",
+            license_expression_spdx="MIT",
+            identifier="mit-123",
+            matches=matches,
+            file_regions=[{"path": "LICENSE", "start_line": 1, "end_line": 1}],
+        )
+
+        url = reverse(
+            "license_detail",
+            args=[self.project1.slug, license_detection.identifier],
+        )
+        response = self.client.get(url)
+
+        self.assertContains(response, "Diagnostic matched text")
+        self.assertContains(response, "License MIT")
+        self.assertContains(response, "Matched text")
+        self.assertContains(response, "License: MIT")
+        self.assertContains(response, "Rule text")
+        self.assertContains(response, "license: MIT")
+
+    def test_scanpipe_views_resource_details_view_inlines_detection_match_texts(self):
+        license_detections = [
+            {
+                "identifier": "mit-123",
+                "license_expression": "mit",
+                "license_expression_spdx": "MIT",
+                "matches": [
+                    {
+                        "score": 100.0,
+                        "start_line": 1,
+                        "end_line": 1,
+                        "matched_length": 4,
+                        "match_coverage": 100.0,
+                        "matcher": "1-hash",
+                        "license_expression": "mit",
+                        "rule_identifier": "mit_1.RULE",
+                        "rule_text": "license: MIT",
+                        "matched_text": "License: MIT",
+                        "matched_text_diagnostics": "License MIT",
+                    }
+                ],
+            }
+        ]
+        resource = make_resource_file(
+            self.project1,
+            "LICENSE",
+            detected_license_expression="mit",
+            license_detections=license_detections,
+        )
+
+        response = self.client.get(resource.get_absolute_url())
+
+        self.assertContains(response, "Diagnostic matched text")
+        self.assertContains(response, "License MIT")
+        self.assertContains(response, "Matched text")
+        self.assertContains(response, "License: MIT")
+        self.assertContains(response, "Rule text")
+        self.assertContains(response, "license: MIT")
 
     @mock.patch("scanpipe.models.DiscoveredPackage.get_absolute_url")
     def test_scanpipe_views_project_dependency_tree(self, mock_get_url):

--- a/scanpipe/tests/test_views.py
+++ b/scanpipe/tests/test_views.py
@@ -1437,6 +1437,135 @@ class ScanPipeViewsTest(TestCase):
         self.assertContains(response, "Rule text")
         self.assertContains(response, "license: MIT")
 
+    def test_scanpipe_views_license_detection_details_view_match_texts_null_from_file(self):
+        matches = [
+            {
+                "score": 100.0,
+                "start_line": 1,
+                "end_line": 1,
+                "matched_length": 3,
+                "match_coverage": 100.0,
+                "matcher": "1-spdx-id",
+                "license_expression": "isc",
+                "rule_identifier": "isc_9931cb7ad33c2eb18f322c94660b670a84186baa.RULE",
+                "matched_text": "ISC",
+                "from_file": None,
+            }
+        ]
+        license_detection = DiscoveredLicense.objects.create(
+            project=self.project1,
+            license_expression="isc",
+            license_expression_spdx="ISC",
+            identifier="isc-null-from-file",
+            matches=matches,
+            detection_count=2,
+            file_regions=[
+                {"path": "a/package.json", "start_line": 1, "end_line": 1},
+                {"path": "b/package-lock.json", "start_line": 1, "end_line": 1},
+            ],
+        )
+
+        url = reverse(
+            "license_detail",
+            args=[self.project1.slug, license_detection.identifier],
+        )
+        response = self.client.get(url)
+
+        self.assertContains(response, "Matches by file")
+        self.assertContains(response, "a/package.json")
+        self.assertContains(response, "b/package-lock.json")
+        self.assertContains(response, "ISC")
+        self.assertNotContains(response, "No match text is available for this file region.")
+        self.assertNotContains(response, "No origin resource path")
+
+    def test_scanpipe_views_license_detection_details_view_match_texts_mixed_from_file(self):
+        matches = [
+            {
+                "score": 100.0,
+                "start_line": 1,
+                "end_line": 1,
+                "matched_length": 4,
+                "match_coverage": 100.0,
+                "matcher": "1-hash",
+                "license_expression": "mit",
+                "rule_identifier": "mit_1.RULE",
+                "matched_text": "License: MIT",
+                "from_file": "LICENSE",
+            },
+            {
+                "score": 100.0,
+                "start_line": 5,
+                "end_line": 5,
+                "matched_length": 3,
+                "match_coverage": 100.0,
+                "matcher": "1-spdx-id",
+                "license_expression": "apache-2.0",
+                "rule_identifier": "apache2_99.RULE",
+                "matched_text": "Apache-2.0",
+                "from_file": None,
+            },
+        ]
+        license_detection = DiscoveredLicense.objects.create(
+            project=self.project1,
+            license_expression="mit AND apache-2.0",
+            license_expression_spdx="MIT AND Apache-2.0",
+            identifier="mixed-from-file",
+            matches=matches,
+            detection_count=3,
+            file_regions=[
+                {"path": "LICENSE", "start_line": 1, "end_line": 1},
+                {"path": "setup.py", "start_line": 5, "end_line": 5},
+            ],
+        )
+
+        url = reverse(
+            "license_detail",
+            args=[self.project1.slug, license_detection.identifier],
+        )
+        response = self.client.get(url)
+
+        self.assertContains(response, "Matches by file")
+        self.assertContains(response, "LICENSE")
+        self.assertContains(response, "setup.py")
+        self.assertContains(response, "License: MIT")
+        self.assertContains(response, "Apache-2.0")
+        self.assertNotContains(response, "No match text is available for this file region.")
+
+    def test_scanpipe_views_license_detection_details_view_match_texts_no_file_regions(self):
+        matches = [
+            {
+                "score": 100.0,
+                "start_line": 1,
+                "end_line": 1,
+                "matched_length": 3,
+                "match_coverage": 100.0,
+                "matcher": "1-spdx-id",
+                "license_expression": "isc",
+                "rule_identifier": "isc_99.RULE",
+                "matched_text": "ISC",
+                "from_file": None,
+            }
+        ]
+        license_detection = DiscoveredLicense.objects.create(
+            project=self.project1,
+            license_expression="isc",
+            license_expression_spdx="ISC",
+            identifier="isc-no-regions",
+            matches=matches,
+            file_regions=[],
+        )
+
+        url = reverse(
+            "license_detail",
+            args=[self.project1.slug, license_detection.identifier],
+        )
+        response = self.client.get(url)
+
+        self.assertContains(response, "Matches by file")
+        self.assertContains(response, "ISC")
+        self.assertContains(response, "No origin resource path")
+        self.assertNotContains(response, "No match text is available for this file region.")
+
     def test_scanpipe_views_resource_details_view_inlines_detection_match_texts(self):
         license_detections = [
             {

--- a/scanpipe/views.py
+++ b/scanpipe/views.py
@@ -2548,12 +2548,18 @@ class DiscoveredLicenseDetailsView(
         matches_by_file = self.get_matches_by_file(self.object.matches)
         file_match_groups = []
 
+        null_from_file_matches = matches_by_file.pop("", [])
+
         for file_region in self.object.file_regions:
             path = file_region.get("path") or ""
+            matches = matches_by_file.pop(path, [])
+            if not matches and null_from_file_matches:
+                matches = null_from_file_matches
+
             file_match_groups.append(
                 {
                     "file_region": file_region,
-                    "matches": matches_by_file.pop(path, []),
+                    "matches": matches,
                 }
             )
 
@@ -2562,6 +2568,14 @@ class DiscoveredLicenseDetailsView(
                 {
                     "file_region": {"path": path},
                     "matches": matches,
+                }
+            )
+
+        if not file_match_groups and null_from_file_matches:
+            file_match_groups.append(
+                {
+                    "file_region": {},
+                    "matches": null_from_file_matches,
                 }
             )
 

--- a/scanpipe/views.py
+++ b/scanpipe/views.py
@@ -2535,6 +2535,43 @@ class DiscoveredLicenseDetailsView(
         },
     }
 
+    @staticmethod
+    def get_matches_by_file(matches):
+        matches_by_file = {}
+        for match in matches:
+            from_file = match.get("from_file") or ""
+            matches_by_file.setdefault(from_file, []).append(match)
+
+        return matches_by_file
+
+    def get_file_match_groups(self):
+        matches_by_file = self.get_matches_by_file(self.object.matches)
+        file_match_groups = []
+
+        for file_region in self.object.file_regions:
+            path = file_region.get("path") or ""
+            file_match_groups.append(
+                {
+                    "file_region": file_region,
+                    "matches": matches_by_file.pop(path, []),
+                }
+            )
+
+        for path, matches in matches_by_file.items():
+            file_match_groups.append(
+                {
+                    "file_region": {"path": path},
+                    "matches": matches,
+                }
+            )
+
+        return file_match_groups
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["file_match_groups"] = self.get_file_match_groups()
+        return context
+
 
 @conditional_login_required
 def run_detail_view(request, uuid):


### PR DESCRIPTION
## Issues

- Closes: #2159 

## Changes
 Improved the license detection review experience by surfacing more context inline and reducing the number of
  clicks needed to inspect detections.

  - Show the diagnostic matched text in single detection views.
  - Show the actual matched text for each listed file directly in the detection details, without requiring extra
    navigation.

  - Present matched and unmatched portions so they can be compared visually.
  - Display the rule text alongside the matched text to make review easier.
  - Restore inline detection details in the resource detections tab to avoid the regression from the older UI.

 ### Before : 
  The detection review flow required too many clicks to inspect a result. The detection details were hidden
  behind additional navigation, which made it easy to lose context while reviewing. The diagnostic matched text
  was also not shown, so it was hard to compare what was matched against the actual rule text and file content.
  
<img width="1044" height="475" alt="image" src="https://github.com/user-attachments/assets/ca91f0c4-f5c8-4d7c-a3b0-abb5bce06c61" />

### After
 The detection details are now shown inline with the resource and detection views, reducing the need to click
  through multiple pages. The diagnostic matched text is visible, and the actual matched text for each file is
  displayed directly with matched and unmatched portions clearly shown. The rule text is also presented
  alongside the matched text, making review faster and easier to understand.
  
<img width="1071" height="892" alt="image" src="https://github.com/user-attachments/assets/102fb5b5-3007-424e-be3d-8fca8c37a9f1" />

 AI usage: Debugging assistance and test generation was done with AI (opencode/big-pickle)
 
 ## Checklist

- [x] I have read the [contributing guidelines](https://github.com/aboutcode-org/scancode.io/blob/main/CONTRIBUTING.md)
- [x] I have linked an existing issue above
- [x] I have added unit tests covering the new code
- [x] I have reviewed and understood every line of this PR