### PR TITLE
Fix IntegrityError on rerun of collect_and_create_codebase_resources

### DIFF
--- a/scanpipe/pipes/__init__.py
+++ b/scanpipe/pipes/__init__.py
@@ -31,6 +31,7 @@ from datetime import datetime
 from itertools import islice
 from pathlib import Path
 
+from django.db import IntegrityError
 from django.db.models import Count
 
 from scanpipe.models import AbstractTaskFieldsModel
@@ -139,12 +140,17 @@ def collect_and_create_codebase_resources(project, batch_size=5000):
     """
     model_class = CodebaseResource
     objs = yield_resources_from_codebase(project)
-
-    while True:
-        batch = list(islice(objs, batch_size))
-        if not batch:
-            break
-        model_class.objects.bulk_create(batch, batch_size)
+    try:
+        while True:
+            batch = list(islice(objs, batch_size))
+            if not batch:
+                break
+            model_class.objects.bulk_create(batch, batch_size)
+    except IntegrityError as e:
+        raise IntegrityError(
+            "Codebase resources already exist for this project. "
+            "Reset the project before re-running."
+        ) from e
 
 
 def update_or_create_resource(project, resource_data):

--- a/scanpipe/tests/pipes/test_pipes.py
+++ b/scanpipe/tests/pipes/test_pipes.py
@@ -25,6 +25,7 @@ import io
 from pathlib import Path
 from unittest import mock
 
+from django.db import IntegrityError
 from django.test import TestCase
 from django.test import TransactionTestCase
 
@@ -448,3 +449,20 @@ class ScanPipePipesTransactionTest(TransactionTestCase):
         self.assertEqual("from", from_resource.tag)
         to_resource = p1.codebaseresources.get(path="to/a.txt")
         self.assertEqual("to", to_resource.tag)
+
+    def test_scanpipe_pipes_collect_and_create_codebase_resources_duplicate_run(self):
+        p1 = Project.objects.create(name="Analysis")
+        input_location = self.data / "codebase" / "a.txt"
+        to_dir = p1.codebase_path / "to"
+        to_dir.mkdir()
+        from_dir = p1.codebase_path / "from"
+        from_dir.mkdir()
+        copy_input(input_location, to_dir)
+        copy_input(input_location, from_dir)
+
+        pipes.collect_and_create_codebase_resources(p1)
+        self.assertEqual(4, p1.codebaseresources.count())
+
+        with self.assertRaises(IntegrityError) as ctx:
+            pipes.collect_and_create_codebase_resources(p1)
+        self.assertIn("Reset", str(ctx.exception))


### PR DESCRIPTION
Rerunning a pipeline that calls collect_and_create_codebase_resources() on a project that already has resources raises a raw IntegrityError. Catch it and re-raise with a message pointing to the Reset feature.

Fixes #1712

## Issues
- Closes: #1712

## Changes
Rerunning map_deploy_to_develop on a project that already has resources blows up on the (project, path) unique constraint for CodebaseResource. Second run tries to insert to/from again, Postgres rejects it, raw IntegrityError hits the UI.

<img width="1786" height="934" alt="Screenshot 2026-09-04 at 14-34-47 ScanCode io rerun-bug-repro" src="https://github.com/user-attachments/assets/53a13b40-5da2-4139-b50d-d1811c401424" />

Root cause is in scanpipe/pipes/__init__.py, collect_and_create_codebase_resources(). Since rerun without reset isn't really supported anyway, wrapped the bulk_create there in try/except and re-raise with a message pointing at Reset instead of the bare trace.

Added a test in scanpipe/tests/pipes/test_pipes.py, right next to the existing test_scanpipe_pipes_collect_and_create_codebase_resources, that reruns the function and checks for the new message.

Ran the full suite locally, passes except one qcow2 extraction test that's already broken on main too (confirmed via git stash).

<img width="1787" height="933" alt="Screenshot 2026-09-04 at 16-43-07 ScanCode io rerun-bug-repro" src="https://github.com/user-attachments/assets/bfc89e5c-3ccf-42ec-b2b2-cc8f56abe6bc" />


## Checklist
- [x] I have read the [[contributing guidelines](https://github.com/aboutcode-org/scancode.io/blob/main/CONTRIBUTING.md)](https://github.com/aboutcode-org/scancode.io/blob/main/CONTRIBUTING.md)
- [x] I have linked an existing issue above
- [x] I have added unit tests covering the new code
- [x] I have reviewed and understood every line of this PR
