### PR TITLE
Ensure the status was not updated after scanned #2228

### DIFF
--- a/scanpipe/pipes/d2d.py
+++ b/scanpipe/pipes/d2d.py
@@ -1556,11 +1556,20 @@ def scan_ignored_to_files(project, logger=None):
         .to_codebase()
         .filter(status=flag.IGNORED_FROM_CONFIG)
     )
+
+    # Capture the specific files id
+    scan_file_ids = list(scan_files.values_list("id", flat=True))
+
+    if not scan_file_ids:
+        return
+
     scancode.scan_for_files(project, scan_files, progress_logger=logger)
 
-    project.codebaseresources.files().to_codebase().filter(status=flag.SCANNED).update(
-        status=flag.IGNORED_FROM_CONFIG
-    )
+    # Revert to the original status value
+    project.codebaseresources.filter(
+        id__in=scan_file_ids,
+        status=flag.SCANNED
+    ).update(status=flag.IGNORED_FROM_CONFIG)
 
 
 def scan_unmapped_to_files(project, logger=None):
@@ -1573,11 +1582,20 @@ def scan_unmapped_to_files(project, logger=None):
         .to_codebase()
         .filter(status=flag.REQUIRES_REVIEW)
     )
+
+    # Capture the specific files id
+    scan_file_ids = list(scan_files.values_list("id", flat=True))
+
+    if not scan_file_ids:
+        return
+
     scancode.scan_for_files(project, scan_files, progress_logger=logger)
 
-    project.codebaseresources.files().to_codebase().filter(status=flag.SCANNED).update(
-        status=flag.REQUIRES_REVIEW
-    )
+    # Revert to the original status value
+    project.codebaseresources.filter(
+        id__in=scan_file_ids,
+        status=flag.SCANNED
+    ).update(status=flag.REQUIRES_REVIEW)
 
 
 def flag_deployed_from_resources_with_missing_license(project, doc_extensions=None):

--- a/scanpipe/pipes/d2d.py
+++ b/scanpipe/pipes/d2d.py
@@ -1566,10 +1566,9 @@ def scan_ignored_to_files(project, logger=None):
     scancode.scan_for_files(project, scan_files, progress_logger=logger)
 
     # Revert to the original status value
-    project.codebaseresources.filter(
-        id__in=scan_file_ids,
-        status=flag.SCANNED
-    ).update(status=flag.IGNORED_FROM_CONFIG)
+    project.codebaseresources.filter(id__in=scan_file_ids, status=flag.SCANNED).update(
+        status=flag.IGNORED_FROM_CONFIG
+    )
 
 
 def scan_unmapped_to_files(project, logger=None):
@@ -1592,10 +1591,9 @@ def scan_unmapped_to_files(project, logger=None):
     scancode.scan_for_files(project, scan_files, progress_logger=logger)
 
     # Revert to the original status value
-    project.codebaseresources.filter(
-        id__in=scan_file_ids,
-        status=flag.SCANNED
-    ).update(status=flag.REQUIRES_REVIEW)
+    project.codebaseresources.filter(id__in=scan_file_ids, status=flag.SCANNED).update(
+        status=flag.REQUIRES_REVIEW
+    )
 
 
 def flag_deployed_from_resources_with_missing_license(project, doc_extensions=None):

--- a/scanpipe/tests/pipes/test_d2d.py
+++ b/scanpipe/tests/pipes/test_d2d.py
@@ -1530,14 +1530,18 @@ class ScanPipeD2DPipesTest(TestCase):
         )
         foo_java.update(status=flag.IGNORED_FROM_CONFIG)
 
+        # Create another file that is already scanned but should not be
+        # reverted
+        other_scanned = make_resource_file(
+            self.project1, "to/other_scanned.txt", status=flag.SCANNED
+        )
+
         d2d.scan_ignored_to_files(self.project1)
         foo_java.refresh_from_db()
+        other_scanned.refresh_from_db()
 
-        expected = self.project1.codebaseresources.filter(
-            status=flag.IGNORED_FROM_CONFIG
-        ).count()
-
-        self.assertEqual(1, expected)
+        self.assertEqual(flag.IGNORED_FROM_CONFIG, foo_java.status)
+        self.assertEqual(flag.SCANNED, other_scanned.status)
 
     def test_scan_unmapped_to_files(self):
         to_dir = (
@@ -1558,14 +1562,18 @@ class ScanPipeD2DPipesTest(TestCase):
         )
         foo_java.update(status=flag.REQUIRES_REVIEW)
 
+        # Create another file that is already scanned but should not be
+        # reverted
+        other_scanned = make_resource_file(
+            self.project1, "to/other_scanned.txt", status=flag.SCANNED
+        )
+
         d2d.scan_unmapped_to_files(self.project1)
         foo_java.refresh_from_db()
+        other_scanned.refresh_from_db()
 
-        expected = self.project1.codebaseresources.filter(
-            status=flag.REQUIRES_REVIEW
-        ).count()
-
-        self.assertEqual(1, expected)
+        self.assertEqual(flag.REQUIRES_REVIEW, foo_java.status)
+        self.assertEqual(flag.SCANNED, other_scanned.status)
 
     def test_flag_deployed_from_resources_with_missing_license(self):
         from_dir = (


### PR DESCRIPTION
## Issues

- Closes: #2228

## Changes

Ensure only the files with statuses IGNORED_FROM_CONFIG and REQUIRES_REVIEW are reverted to their original statuses after scanning.

Previouly
```
    project.codebaseresources.files().to_codebase().filter(status=flag.SCANNED).update(
        status=flag.IGNORED_FROM_CONFIG
    )
```
and
```
    project.codebaseresources.files().to_codebase().filter(status=flag.SCANNED).update(
        status=flag.REQUIRES_REVIEW
    )
```
will update all the files that have `status=flag.SCANNED` which is not correct.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/aboutcode-org/scancode.io/blob/main/CONTRIBUTING.md)
- [x] I have linked an existing issue above
- [x] I have added unit tests covering the new code
- [x] I have reviewed and understood every line of this PR
